### PR TITLE
Fix: Tail version output in case gradle plugin prints on stdout

### DIFF
--- a/.github/workflows/deploy-grpc.yml
+++ b/.github/workflows/deploy-grpc.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Get docker tag and deployment env
         id: get_context
         run: |
-          VERSION=$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet ${{ env.final_name }}:currentVersion )
+          VERSION=$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet ${{ env.final_name }}:currentVersion | tail -n1 )
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=image_name::eu.gcr.io/attraqt-xo/${{ env.final_name }}:$VERSION"
           echo "::set-output name=gateway_image_name::eu.gcr.io/attraqt-xo/items-grpc-gateway:$VERSION"

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -55,7 +55,7 @@ jobs:
       - id: get_version_env
         name: Get job version and deployment env
         run: |
-          echo "::set-output name=version::$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet ${{ env.job_location }}:${{ env.global_job_name }}:currentVersion )"
+          echo "::set-output name=version::$([ '${{ github.ref }}' == 'refs/heads/master' ] && git rev-parse --short HEAD || ./gradlew --quiet --console=plain -Prelease.quiet ${{ env.job_location }}:${{ env.global_job_name }}:currentVersion | tail -n1 )"
           echo "::set-output name=env::$([ '${{ github.ref }}' == 'refs/heads/master' ] && echo 'dev' || echo 'prod')"
 
       - name: Publish Dataflow Template


### PR DESCRIPTION
Some gradle plugins may print on `stdout`, even when `--quiet` is specified.
In case this happens, only get the last line when fetching the version from gradle